### PR TITLE
chore: add linux to autobuilder

### DIFF
--- a/.github/workflows/godot.yml
+++ b/.github/workflows/godot.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        platform: [win64] #, linux, mac]
+        platform: [win64, linux, mac]
     steps:
       - name: Format Tag Name
         id: replace_string
@@ -25,16 +25,16 @@ jobs:
           lfs: true
       - name: Build
         id: build
-        uses: yeslayla/build-godot-action@v1.5.0
+        uses: felix-schindler/build-godot-action@v2.0.0
         with:
-          name: "Reia_${{ steps.replace_string.outputs.replaced }}.exe"
+          name: "Reia_${{ steps.replace_string.outputs.replaced }}"
           preset: ${{ matrix.platform }}
           debugMode: "false"
       - name: Create Release And Upload Asset
         uses: softprops/action-gh-release@v1
         if: ${{startsWith(github.ref, 'refs/tags/') }}
         with:
-          files: build/Reia_${{ steps.replace_string.outputs.replaced }}.exe
+          files: build/Reia_${{ steps.replace_string.outputs.replaced }}
           body: |
             # Reia - `${{ github.ref_name }}`
 


### PR DESCRIPTION
I updated the workflow to use someone else's fork that has a few issues resolved and added the build target to be Linux,Windows, and Mac. 

Closes #19