### PR TITLE
Fix: the GitHub Actions workflow for all platform builds

### DIFF
--- a/.github/workflows/godot.yml
+++ b/.github/workflows/godot.yml
@@ -136,7 +136,7 @@ jobs:
   # Runs only on tag pushes once all export jobs succeed.
   # ---------------------------------------------------------------------------
   release:
-    name: Create Release
+    name: Create Release & Deploy to R2
     runs-on: ubuntu-latest
     needs: export
     if: ${{ always() && !cancelled() && needs.export.result == 'success' && startsWith(github.ref, 'refs/tags/') }}
@@ -146,22 +146,94 @@ jobs:
         with:
           submodules: recursive
 
-      - name: Format tag for release name
-        id: replace_string
-        uses: frabert/replace-string-action@v2
+      - name: Download Artifacts
+        uses: actions/download-artifact@v4
         with:
-          pattern: '\.'
-          string: ${{ github.ref_name }}
-          replace-with: "_"
+          path: unzipped_artifacts
 
-      - name: Publish GitHub release
+      - name: Package Distributions and Generate Manifest
+        run: |
+          mkdir -p staging_latest
+          mkdir -p staging_versioned
+          
+          # Zip build directories
+          if [ -d "unzipped_artifacts/windows" ]; then
+            cd unzipped_artifacts/windows && zip -r ../../staging_latest/reia-windows.zip . && cd ../..
+          fi
+          if [ -d "unzipped_artifacts/linux" ]; then
+            cd unzipped_artifacts/linux && zip -r ../../staging_latest/reia-linux.zip . && cd ../..
+          fi
+          if [ -d "unzipped_artifacts/server" ]; then
+            cd unzipped_artifacts/server && zip -r ../../staging_latest/reia-linux-server.zip . && cd ../..
+          fi
+          if [ -d "unzipped_artifacts/mac" ]; then
+            cd unzipped_artifacts/mac && zip -r ../../staging_latest/reia-macos.zip . && cd ../..
+          fi
+
+          # Calculate SHA256 hashes
+          WIN_HASH=$(sha256sum staging_latest/reia-windows.zip 2>/dev/null | awk '{print $1}')
+          LIN_HASH=$(sha256sum staging_latest/reia-linux.zip 2>/dev/null | awk '{print $1}')
+          SRV_HASH=$(sha256sum staging_latest/reia-linux-server.zip 2>/dev/null | awk '{print $1}')
+          MAC_HASH=$(sha256sum staging_latest/reia-macos.zip 2>/dev/null | awk '{print $1}')
+
+          # Generate Manifest for /latest/
+          cat <<EOF > staging_latest/manifest.json
+          {
+            "version": "latest",
+            "binaries": {
+              "Windows": { "file": "reia-windows.zip", "sha256": "$WIN_HASH" },
+              "Linux": { "file": "reia-linux.zip", "sha256": "$LIN_HASH" },
+              "Linux Server": { "file": "reia-linux-server.zip", "sha256": "$SRV_HASH" },
+              "macOS": { "file": "reia-macos.zip", "sha256": "$MAC_HASH" }
+            }
+          }
+          EOF
+
+          # Copy zipped binaries over to versioned staging area
+          cp staging_latest/*.zip staging_versioned/
+
+          # Clean version name string (e.g., v1.0.0 -> 1.0.0)
+          CLEAN_VERSION=$(echo "${{ github.ref_name }}" | sed 's/^v//')
+
+          # Generate Manifest for versioned directory
+          cat <<EOF > staging_versioned/manifest.json
+          {
+            "version": "$CLEAN_VERSION",
+            "binaries": {
+              "Windows": { "file": "reia-windows.zip", "sha256": "$WIN_HASH" },
+              "Linux": { "file": "reia-linux.zip", "sha256": "$LIN_HASH" },
+              "Linux Server": { "file": "reia-linux-server.zip", "sha256": "$SRV_HASH" },
+              "macOS": { "file": "reia-macos.zip", "sha256": "$MAC_HASH" }
+            }
+          }
+          EOF
+
+      - name: Sync Releases to Cloudflare R2
+        env:
+          AWS_ACCESS_KEY_ID: ${{ secrets.R2_ACCESS_KEY_ID }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.R2_SECRET_ACCESS_KEY }}
+          AWS_DEFAULT_REGION: auto
+        run: |
+          CLEAN_VERSION=$(echo "${{ github.ref_name }}" | sed 's/^v//')
+          
+          # Deploy to /releases/latest/
+          aws s3 sync staging_latest/ s3://game-build/releases/latest/ \
+            --endpoint-url https://${{ secrets.R2_ACCOUNT_ID }}.r2.cloudflarestorage.com \
+            --delete
+
+          # Deploy to versioned folder (e.g., /releases/1.0.0/)
+          aws s3 sync staging_versioned/ s3://game-build/releases/$CLEAN_VERSION/ \
+            --endpoint-url https://${{ secrets.R2_ACCOUNT_ID }}.r2.cloudflarestorage.com \
+            --delete
+
+      - name: Publish GitHub Release Artifacts
         uses: softprops/action-gh-release@v2
         with:
           files: |
-            build/windows
-            build/linux
-            build/server
-            build/mac
+            staging_latest/reia-windows.zip
+            staging_latest/reia-linux.zip
+            staging_latest/reia-linux-server.zip
+            staging_latest/reia-macos.zip
           tag_name: ${{ github.ref_name }}
           body: |
             # Reia - `${{ github.ref_name }}`

--- a/.github/workflows/godot.yml
+++ b/.github/workflows/godot.yml
@@ -7,181 +7,161 @@ on:
       - 'v[0-9]+.[0-9]+.[0-9]+([a-zA-Z]*\-*)*'
 
 env:
-  GODOT_VERSION: 4.5.1
+  GODOT_VERSION: 4.6
   EXPORT_NAME: Reia
   PROJECT_PATH: godot
   WINEPREFIX: /tmp/.wine
 
 jobs:
-  build-gdextension:
-    name: Build Rust GDExtension (${{ matrix.platform }})
-    runs-on: ${{ matrix.runner }}
-    strategy:
-      matrix:
-        include:
-          - platform: windows
-            runner: windows-latest
-            target: x86_64-pc-windows-msvc
-            output: dll
-          # - platform: linux
-          #   runner: ubuntu-24.04
-          #   target: x86_64-unknown-linux-gnu
-          #   output: so
-          # - platform: mac
-          #   runner: macos-15
-          #   target: x86_64-apple-darwin
-          #   output: dylib
-          # - platform: web
-          #   runner: ubuntu-24.04
-          #   target: wasm32-unknown-unknown
-          #   output: wasm
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v5
-        with:
-          submodules: recursive
-      - name: Cache Rust dependencies
-        uses: actions/cache@v4
-        with:
-          path: |
-            ~/.cargo/registry
-            ~/.cargo/git
-            rust/target
-          key: ${{ runner.os }}-cargo-${{ matrix.target }}-${{ hashFiles('**/Cargo.lock') }}
-          restore-keys: |
-            ${{ runner.os }}-cargo-${{ matrix.target }}-
-            ${{ runner.os }}-cargo-
-      - name: Ensure custom LFS config (Rust)
-        run: |
-          git lfs pull
-      - name: Install Rust
-        uses: actions-rs/toolchain@v1
-        with:
-          toolchain: stable
-          target: ${{ matrix.target }}
-          override: true
-      - name: Build GDExtension
-        run: |
-          cd rust
-          cargo build --release --target ${{ matrix.target }}
-      - name: Upload GDExtension artifact
-        uses: actions/upload-artifact@v5
-        with:
-          name: ${{ matrix.target }}
-          path: rust/target/${{ matrix.target }}/release/reia.${{ matrix.output }}
-
+  # ---------------------------------------------------------------------------
+  # Export
+  # Rust binaries are not built here. They are built by the "Build and Upload
+  # GDExtension" workflow and published to Cloudflare R2. This job pulls the
+  # latest release binaries from R2 and places them where reia.gdextension
+  # expects them (res://build/bin/) before invoking the headless export.
+  # ---------------------------------------------------------------------------
   export:
-    needs: build-gdextension
     name: Export (${{ matrix.export }})
     runs-on: ${{ matrix.runner }}
     container:
-      image: barichello/godot-ci:4.5.1
+      image: barichello/godot-ci:4.6
     strategy:
+      fail-fast: false
       matrix:
         include:
           - export: windows
             runner: ubuntu-24.04
-            artifact: x86_64-pc-windows-msvc
             ext: exe
             godot_export: win
             output_dir: build/windows
             export_name: windows
-          # - export: linux
-          #   runner: ubuntu-24.04
-          #   artifact: x86_64-unknown-linux-gnu
-          #   ext: x86_64
-          #   godot_export: linux
-          #   output_dir: build/linux
-          #   export_name: linux
-          # - export: server
-          #   runner: ubuntu-24.04
-          #   artifact: x86_64-unknown-linux-gnu
-          #   ext: x86_64
-          #   godot_export: server
-          #   output_dir: build/server
-          #   export_name: server
-          # - export: mac
-          #   runner: ubuntu-24.04
-          #   artifact: x86_64-apple-darwin
-          #   ext: zip
-          #   godot_export: mac
-          #   output_dir: build/mac
-          #   export_name: mac
+          - export: linux
+            runner: ubuntu-24.04
+            ext: x86_64
+            godot_export: linux
+            output_dir: build/linux
+            export_name: linux
+          - export: server
+            runner: ubuntu-24.04
+            ext: x86_64
+            godot_export: server
+            output_dir: build/server
+            export_name: server
+          - export: mac
+            runner: ubuntu-24.04
+            ext: zip
+            godot_export: mac
+            output_dir: build/mac
+            export_name: mac
+          # Web export is intentionally excluded from this workflow.
+          # Reia's networking stack (Quinn, libsql, Tokio) requires native I/O
+          # and cannot target WASM. The web client will be a separate, lightweight
+          # Godot project that bridges to the backend over the network.
           # - export: web
           #   runner: ubuntu-24.04
-          #   artifact: wasm32-unknown-unknown
           #   ext: html
           #   godot_export: web
           #   output_dir: build/web
           #   export_name: web
     steps:
       - name: Checkout
-        uses: actions/checkout@v5
+        uses: actions/checkout@v4
         with:
           submodules: recursive
-      - name: Cache Godot export templates
+
+      - name: Restore Godot editor cache
+        uses: actions/cache@v4
+        with:
+          path: ${{ env.PROJECT_PATH }}/.godot/
+          key: godot-editor-${{ env.GODOT_VERSION }}-${{ hashFiles(format('{0}/**/*.tscn', env.PROJECT_PATH), format('{0}/**/*.gd', env.PROJECT_PATH), format('{0}/**/*.import', env.PROJECT_PATH)) }}
+          restore-keys: |
+            godot-editor-${{ env.GODOT_VERSION }}-
+
+      - name: Restore Godot export templates
         uses: actions/cache@v4
         with:
           path: ~/.local/share/godot/export_templates/
-          key: ${{ runner.os }}-godot-templates-${{ env.GODOT_VERSION }}
+          key: godot-templates-${{ env.GODOT_VERSION }}
           restore-keys: |
-            ${{ runner.os }}-godot-templates-
-      - name: Ensure custom LFS config (Godot)
+            godot-templates-
+
+      - name: Ensure LFS objects are present
         working-directory: ${{ github.workspace }}
         run: |
           git config --global --add safe.directory "$GITHUB_WORKSPACE"
           git lfs install --local
           git lfs pull
-      - name: Download Rust GDExtension
-        uses: actions/download-artifact@v6
-        with:
-          name: ${{ matrix.artifact }}
-          path: rust/target/${{ matrix.artifact }}/release/
-      - name: Setup
+
+      - name: Pull GDExtension binaries from R2
+        env:
+          AWS_ACCESS_KEY_ID: ${{ secrets.R2_ACCESS_KEY_ID }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.R2_SECRET_ACCESS_KEY }}
+          AWS_DEFAULT_REGION: auto
+        run: |
+          mkdir -p ${{ env.PROJECT_PATH }}/build/bin
+          aws s3 sync s3://rust-build/latest/ ${{ env.PROJECT_PATH }}/build/bin/ \
+            --endpoint-url https://${{ secrets.R2_ACCOUNT_ID }}.r2.cloudflarestorage.com \
+            --exclude "*" \
+            --include "*.release.*"
+
+      - name: Setup export template paths
         run: |
           mkdir -v -p ~/.local/share/godot/export_templates/
           mkdir -v -p ~/.config/
           mv /root/.config/godot ~/.config/godot || true
-          mv /root/.local/share/godot/export_templates/${GODOT_VERSION}.stable ~/.local/share/godot/export_templates/${GODOT_VERSION}.stable || true
-      - name: Export Build
+          mv /root/.local/share/godot/export_templates/${GODOT_VERSION}.stable \
+             ~/.local/share/godot/export_templates/${GODOT_VERSION}.stable || true
+
+      - name: Import project assets
+        run: |
+          cd ${{ env.PROJECT_PATH }}
+          godot --headless --import || true
+
+      - name: Export build
         run: |
           mkdir -v -p ${{ matrix.output_dir }}
           EXPORT_DIR="$(readlink -f build)"
-          cd $PROJECT_PATH
-          godot --headless --verbose --export-release "${{ matrix.godot_export }}" "$EXPORT_DIR/${{ matrix.export_name }}/${EXPORT_NAME}.${{ matrix.ext }}"
-      - name: Upload Artifact
-        uses: actions/upload-artifact@v5
+          cd ${{ env.PROJECT_PATH }}
+          godot --headless --verbose --export-release "${{ matrix.godot_export }}" \
+            "$EXPORT_DIR/${{ matrix.export_name }}/${EXPORT_NAME}.${{ matrix.ext }}"
+
+      - name: Upload build artifact
+        uses: actions/upload-artifact@v4
         with:
           name: ${{ matrix.export_name }}
           path: ${{ matrix.output_dir }}
 
-  release-notes:
-    name: Release Notes
+  # ---------------------------------------------------------------------------
+  # Release
+  # Runs only on tag pushes once all export jobs succeed.
+  # ---------------------------------------------------------------------------
+  release:
+    name: Create Release
     runs-on: ubuntu-latest
     needs: export
     if: ${{ always() && !cancelled() && needs.export.result == 'success' && startsWith(github.ref, 'refs/tags/') }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v5
+        uses: actions/checkout@v4
         with:
           submodules: recursive
-      - name: Format Tag Name
+
+      - name: Format tag for release name
         id: replace_string
         uses: frabert/replace-string-action@v2
         with:
           pattern: '\.'
           string: ${{ github.ref_name }}
           replace-with: "_"
-      - name: Create Release And Upload Asset
+
+      - name: Publish GitHub release
         uses: softprops/action-gh-release@v2
-        if: ${{ startsWith(github.ref, 'refs/tags/') }}
         with:
           files: |
             build/windows
-          # build/linux
-          # build/server
-          # build/mac
-          # build/web
+            build/linux
+            build/server
+            build/mac
           tag_name: ${{ github.ref_name }}
           body: |
             # Reia - `${{ github.ref_name }}`


### PR DESCRIPTION
Fixes #36.

### What changed

**Removed `build-gdextension` job**
Rust binaries are already built by the `Build and Upload GDExtension`
workflow and published to Cloudflare R2. Building them again in this
workflow was redundant. The export job now pulls release binaries
directly from R2 using the same secrets already configured for
`upload_rust.yml`.

**Bumped `GODOT_VERSION` from `4.5.1` to `4.6`**
`reia.gdextension` declares `compatibility_minimum = 4.6`. Running
the export with `4.5.1` caused Godot to refuse loading the extension
on startup, which cascaded into every GDScript referencing `RustCore`
failing to parse.

**Enabled Linux, Server, and Mac exports**
All three were commented out. Uncommented and added to the release
upload file list.

**Fixed binary destination path**
The old workflow downloaded artifacts into `rust/target/.../release/`
but `reia.gdextension` expects binaries at `res://build/bin/` with
full platform names. The R2 sync step places files at
`godot/build/bin/` which resolves to `res://build/bin/` at runtime.

**Added `.godot/` editor cache**
Per discussion in #36 — using action cache instead of committing the
folder. Keyed on `.tscn`, `.gd`, and `.import` file hashes so it
invalidates correctly when scenes or scripts change.

**Added `--import` step before export**
Handles cold or stale cache without causing a multi-hour hang on asset
reimport.

**Web export kept as a comment**
Reia's networking stack (Quinn, libsql, Tokio) cannot target WASM.
Left as a comment with an explanation that the web client will be a
separate Godot project bridging over the network.

**Pinned all actions to `@v4`**
Consistent with `upload_rust.yml`.