### PR TITLE
Limit workflow permissions.

### DIFF
--- a/.github/workflows/godot.yml
+++ b/.github/workflows/godot.yml
@@ -6,6 +6,9 @@ on:
     tags:
       - 'v[0-9]+.[0-9]+.[0-9]+([a-zA-Z]*\-*)*'
 
+permissions:
+  contents: write  # Required for softprops/action-gh-release to create releases and upload assets
+
 env:
   GODOT_VERSION: 4.6
   EXPORT_NAME: Reia

--- a/.github/workflows/upload_rust.yml
+++ b/.github/workflows/upload_rust.yml
@@ -8,6 +8,10 @@ on:
     paths:
       - "rust/**" # Only run if Rust code changes
 
+# Explicitly lock down the token to read-only for security compliance
+permissions:
+  contents: read   # Required for actions/checkout to pull down the repository source
+
 jobs:
   # Matrix Build
   build-binaries:


### PR DESCRIPTION
This pull request updates the GitHub Actions workflows to explicitly set permissions for better security and compliance. The main changes involve specifying the minimum required permissions for each workflow.

**Workflow permissions updates:**

* **Godot workflow:**
  - Added `contents: write` permission to allow the workflow to create releases and upload assets, which is required by `softprops/action-gh-release`.

* **Rust upload workflow:**
  - Added `contents: read` permission to restrict the GitHub token to read-only access, improving security and ensuring only the necessary permissions are granted for `actions/checkout`.

Closes #47